### PR TITLE
fix test to use renamed FileSet.Add from 92064e8e82bf117004facc854b8cb50...

### DIFF
--- a/token/token_test.go
+++ b/token/token_test.go
@@ -52,8 +52,8 @@ func TestFilePosition(t *testing.T) {
 
 func TestFileSetPosition(t *testing.T) {
 	fs := token.NewFileSet()
-	fs.AddFile("testA.calc", test_expr)
-	fs.AddFile("testB.calc", test_expr)
+	fs.Add("testA.calc", test_expr)
+	fs.Add("testB.calc", test_expr)
 }
 
 func TestLookup(t *testing.T) {


### PR DESCRIPTION
I'm new to Go, but I've made a habit of writing compilers in other languages. Learning a lot through your code. Thanks.
