### PR TITLE
Fixing \n in code.  Before, Go was interreting the \n, I changed it t…

### DIFF
--- a/comp/comp.go
+++ b/comp/comp.go
@@ -81,7 +81,7 @@ func (c *compiler) compBinaryExpr(b *ast.BinaryExpr) int {
 func (c *compiler) compFile(f *ast.File) {
 	fmt.Fprintln(c.fp, "#include <stdio.h>")
 	fmt.Fprintln(c.fp, "int main(void) {")
-	fmt.Fprintf(c.fp, "printf(\"%%d\n\", %d);\n", c.compNode(f.Root))
+	fmt.Fprintf(c.fp, "printf(\"%%d\\n\", %d);\n", c.compNode(f.Root))
 	fmt.Fprintln(c.fp, "return 0;")
 	fmt.Fprintln(c.fp, "}")
 }


### PR DESCRIPTION
Fixing newline in code.  Before, Go was interpreting the \n, I changed it \n so that \n appeared in the outputted .c file.  Before this change, the outputted c file wouldn't compile.

Before:
# include <stdio.h>

int main(void) {
printf("%d
", 10);
return 0;
}

Now:
# include <stdio.h>

int main(void) {
printf("%d\n", 10);
return 0;
}
